### PR TITLE
Enable Node Convert to base k3s.

### DIFF
--- a/pkg/kube/Dockerfile
+++ b/pkg/kube/Dockerfile
@@ -29,6 +29,7 @@ COPY --from=build /out/ /
 COPY cluster-init.sh /usr/bin/
 COPY cluster-utils.sh /usr/bin/
 COPY cgconfig.conf /etc
+COPY utils.sh /usr/bin/
 
 # upgrades
 COPY cluster-update.sh /usr/bin/
@@ -48,6 +49,7 @@ COPY multus-daemonset.yaml /etc
 COPY kubevirt-operator.yaml /etc
 COPY kubevirt-features.yaml /etc
 COPY external-boot-image.tar /etc/
+COPY kubevirt-utils.sh /usr/bin/
 
 # Longhorn config
 COPY longhorn-utils.sh /usr/bin/
@@ -55,6 +57,7 @@ COPY lh-cfg-v1.6.3.yaml /etc/
 COPY iscsid.conf /etc/iscsi/
 COPY longhorn-generate-support-bundle.sh /usr/bin/
 COPY nsmounter /usr/bin/
+COPY longhorn_uninstall_settings.yaml /etc/
 
 # descheduler
 COPY descheduler-utils.sh /usr/bin/

--- a/pkg/kube/cluster-utils.sh
+++ b/pkg/kube/cluster-utils.sh
@@ -291,3 +291,9 @@ wait_for_default_route() {
         done < /proc/net/route
         return 1
 }
+
+Multus_uninstall() {
+        logmsg "multus uninstall"
+        kubectl delete -f /etc/multus-daemonset-new.yaml
+        rm /var/lib/multus_initialized
+}

--- a/pkg/kube/descheduler-utils.sh
+++ b/pkg/kube/descheduler-utils.sh
@@ -7,7 +7,6 @@ DESCHEDULER_VERSION="v0.29.0"
 
 descheduler_install()
 {
-    logmsg "Applying Descheduler ${DESCHEDULER_VERSION}"
     if ! kubectl apply -f /etc/descheduler_rbac.yaml; then
             logmsg "descheduler rbac not yet applied"
             return 1
@@ -17,4 +16,17 @@ descheduler_install()
             return 1
     fi
     return 0
+}
+
+Descheduler_uninstall() {
+        logmsg "Removing Descheduler ${DESCHEDULER_VERSION}"
+        if ! kubectl delete -f /etc/descheduler-policy-configmap.yaml; then
+                logmsg "descheduler config not deleted"
+                return 1
+        fi
+        if ! kubectl delete -f /etc/descheduler_rbac.yaml; then
+                logmsg "descheduler not deleted"
+                return 1
+        fi
+        return 0
 }

--- a/pkg/kube/kubevirt-utils.sh
+++ b/pkg/kube/kubevirt-utils.sh
@@ -1,0 +1,40 @@
+#!/bin/sh
+#
+# Copyright (c) 2025 Zededa, Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+KUBEVIRT_VERSION=v1.1.0
+CDI_VERSION=v1.57.1
+
+Kubevirt_install() {
+    # This patched version will be removed once the following PR https://github.com/kubevirt/kubevirt/pull/9668 is merged
+    logmsg "Installing patched Kubevirt"
+    kubectl apply -f /etc/kubevirt-operator.yaml
+    logmsg "Updating replica to 1 for virt-operator and virt-controller"
+    kubectl patch deployment virt-operator -n kubevirt --patch '{"spec":{"replicas": 1 }}'
+    kubectl apply -f https://github.com/kubevirt/kubevirt/releases/download/${KUBEVIRT_VERSION}/kubevirt-cr.yaml
+    kubectl patch KubeVirt kubevirt -n kubevirt --patch '{"spec": {"infra": {"replicas": 1}}}' --type='merge'
+    #Add kubevirt feature gates
+    kubectl apply -f /etc/kubevirt-features.yaml
+}
+
+Kubevirt_uninstall() {
+    logmsg "Removing patched Kubevirt"
+    kubectl delete -f /etc/kubevirt-features.yaml
+    kubectl delete -f /etc/kubevirt-operator.yaml
+    rm /var/lib/kubevirt_initialized
+}
+
+Cdi_install() {
+    #CDI (containerzed data importer) is need to convert qcow2/raw formats to Persistent Volumes and Data volumes
+    logmsg "Installing CDI version $CDI_VERSION"
+    kubectl create -f https://github.com/kubevirt/containerized-data-importer/releases/download/$CDI_VERSION/cdi-operator.yaml
+    kubectl create -f https://github.com/kubevirt/containerized-data-importer/releases/download/$CDI_VERSION/cdi-cr.yaml
+}
+
+Cdi_uninstall() {
+    #CDI (containerzed data importer) is need to convert qcow2/raw formats to Persistent Volumes and Data volumes
+    logmsg "Removing CDI version $CDI_VERSION"
+    kubectl delete -f https://github.com/kubevirt/containerized-data-importer/releases/download/$CDI_VERSION/cdi-cr.yaml
+    kubectl delete -f https://github.com/kubevirt/containerized-data-importer/releases/download/$CDI_VERSION/cdi-operator.yaml
+}

--- a/pkg/kube/longhorn-utils.sh
+++ b/pkg/kube/longhorn-utils.sh
@@ -19,6 +19,42 @@ longhorn_install() {
     return 0
 }
 
+Longhorn_uninstall() {
+    logmsg "longhorn_uninstall ${LONGHORN_VERSION} beginning"
+    while ! kubectl apply -f /etc/longhorn_uninstall_settings.yaml; do
+        sleep 5
+    done
+    logmsg "longhorn_uninstall: set uninstall setting"
+
+    while ! kubectl create -f https://raw.githubusercontent.com/longhorn/longhorn/${LONGHORN_VERSION}/uninstall/uninstall.yaml; do
+        sleep 5
+    done
+    logmsg "longhorn_uninstall job wait begun"
+
+    # A clean, unbusy system can take ~1 min, allow for some delay
+    i=1
+    while [ $i -lt 1000 ]; do
+        success=$(kubectl get job/longhorn-uninstall -n longhorn-system -o jsonpath='{.status.succeeded}')
+        if [ "$success" = "1" ]; then
+                logmsg "longhorn_uninstall job success"
+                break
+        fi
+        sleep 5
+        i=$((i+1))
+    done
+    logmsg "longhorn_uninstall job wait stopped"
+
+    # Can return failure for non-fatal conditions
+    kubectl delete -f https://raw.githubusercontent.com/longhorn/longhorn/${LONGHORN_VERSION}/deploy/longhorn.yaml
+    logmsg "longhorn_uninstall deploy deleted"
+
+    kubectl delete -f https://raw.githubusercontent.com/longhorn/longhorn/${LONGHORN_VERSION}/uninstall/uninstall.yaml
+    logmsg "longhorn_uninstall job deletion"
+    
+    rm /var/lib/longhorn_initialized
+    return 0
+}
+
 longhorn_is_ready() {
     lhStatus=$(kubectl -n longhorn-system get daemonsets -o json | jq '.items[].status | .numberReady==.desiredNumberScheduled' | tr -d '\n')
     if [ "$lhStatus" != "truetruetrue" ]; then

--- a/pkg/kube/longhorn_uninstall_settings.yaml
+++ b/pkg/kube/longhorn_uninstall_settings.yaml
@@ -1,0 +1,9 @@
+# Copyright (c) 2025 Zededa, Inc.
+# SPDX-License-Identifier: Apache-2.0
+---
+apiVersion: longhorn.io/v1beta2
+kind: Setting
+metadata:
+  name: deleting-confirmation-flag
+  namespace: longhorn-system
+value: "true"

--- a/pkg/kube/utils.sh
+++ b/pkg/kube/utils.sh
@@ -1,0 +1,15 @@
+#!/bin/sh
+#
+# Copyright (c) 2025 Zededa, Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+is_amd64() {
+    mach_type=$(uname -m)
+    if [ "$mach_type" = "x86_64" ]; then
+        return 0
+    fi
+    if [ "$mach_type" = "amd64" ]; then
+        return 0
+    fi
+    return 1
+}


### PR DESCRIPTION
Requires #15 merged first.


- Move component install steps to clean functions
- Uninstall components if registration completes. This marks conversion from edge node storage cluster which provides VMs on replicated storage to a simpler kubernetes cluster awaiting further config.
- Enable all_components_initialized on arm64 by skipping install of kubevirt/cdi components.  CDI is amd64 only at least in this  version.
- Skip calling longhorn API when it's not expected to be available.  This is used in pillar node drain path as well as replicated volume instance metrics.  Search for the longhorn-system namespace to determine if the longhorn http api is expected to be available.


(cherry picked from commit 0d73ef4d4885e99f9b188e0535aee37a6c47a3dc)

# Description

<!-- Clear description what this PR does and why it's needed -->

<!-- For Backport PRs, please note the following:

- Add a note to indicate the origin of the fix, for example:

Backport of #<original-PR-number>

- PR's title should also indicate the stable branch, for instance:

[<stable-branch>] Original's PR title
-->

## PR dependencies

<!-- List all dependencies of this PR (when applicable) -->

## How to test and validate this PR

<!-- Please describe how the changes in this PR can be validated or
verified. For example:

- If your PR fixes a bug, outline the steps to confirm the issue is resolved.
- If your PR introduces a new feature, explain how to test and validate it.
-->

## Changelog notes

<!-- Short description to be included in the ChangeLog notes -->

## PR Backports

<!-- When applicable, list all stable branches that must have this PR
backported. For example:

- [ ] 13.4-stable
- [ ] 12.0-stable
-->

## Checklist

- [ ] I've provided a proper description
- [ ] I've added the proper documentation (when applicable)
- [ ] I've tested my PR on amd64 device(s)
- [ ] I've tested my PR on arm64 device(s)
- [ ] I've written the test verification instructions
- [ ] I've set the proper labels to this PR
<!-- For Backport PRs only:
- [ ] I've added a reference link to the original PR
- [ ] PR's title follows the template ([<stable-branch>] Original's PR Title)
-->
