### PR TITLE
Enable Node Convert to base k3s (fixes)

### DIFF
--- a/pkg/kube/cluster-init.sh
+++ b/pkg/kube/cluster-init.sh
@@ -611,6 +611,8 @@ monitor_cluster_config_change() {
 
 # started when we detect registration addition
 # start cleaning up some components
+# these are cluster-wide operations, only one nodes initates it
+# Marked via the Registration_Exists fence
 uninstall_components() {
         logmsg "Post-registration cleanup steps: wait api available"
         while ! kubectl cluster-info; do
@@ -618,7 +620,7 @@ uninstall_components() {
         done
         logmsg "Post-registration cleanup steps: kubectl cluster-info ready, wait nodes ready"
         while true; do
-                # shellcheck disable=SC2281,SC2154,SC2046
+                # shellcheck disable=SC2281,SC2154,SC2046,SC2016
                 $not_ready_nodes=$(kubectl get nodes -o go-template='{{range .items}}{{ $ready := false }}{{range .status.conditions}}{{if and (eq .type "Ready") (eq .status "True")}}{{ $ready = true }}{{end}}{{end}}{{if not $ready}}{{.metadata.name}}{{"\n"}}{{end}}{{end}}')
                 if [ "$not_ready_nodes" = "" ]; then
                         break

--- a/pkg/kube/longhorn-generate-support-bundle.sh
+++ b/pkg/kube/longhorn-generate-support-bundle.sh
@@ -5,6 +5,14 @@
 
 LOG_DIR=/persist/kubelog
 
+# This script is called from collect-info, help it avoid a timeout
+# by checking for longhorn installed state and return before applying 
+# the support bundle manifest.
+if ! kubectl get namespace/longhorn-system; then
+    echo "Longhorn not installed, skipping SupportBundle"
+    exit 1
+fi
+
 echo "Apply longhorn support bundle yaml at $(date)"
 
 cat <<EOF | kubectl apply -f -

--- a/pkg/kube/longhorn-utils.sh
+++ b/pkg/kube/longhorn-utils.sh
@@ -31,7 +31,7 @@ Longhorn_uninstall() {
     done
     logmsg "longhorn_uninstall job wait begun"
 
-    # A clean, unbusy system can take ~1 min, allow for some delay
+    # A clean idle system can take ~1 min, allow for some delay
     i=1
     while [ $i -lt 1000 ]; do
         success=$(kubectl get job/longhorn-uninstall -n longhorn-system -o jsonpath='{.status.succeeded}')
@@ -50,7 +50,6 @@ Longhorn_uninstall() {
 
     kubectl delete -f https://raw.githubusercontent.com/longhorn/longhorn/${LONGHORN_VERSION}/uninstall/uninstall.yaml
     logmsg "longhorn_uninstall job deletion"
-    
     rm /var/lib/longhorn_initialized
     return 0
 }


### PR DESCRIPTION
(additions from master commit id 250e056: waitFor and yetus)

- Move component install steps to clean functions
- Uninstall components if registration completes. This marks conversion from edge node storage cluster which provides VMs on replicated storage to a simpler kubernetes cluster awaiting further config.
- Enable all_components_initialized on arm64 by skipping install of kubevirt/cdi components.  CDI is amd64 only at least in this  version.
- Skip calling longhorn API when it's not expected to be available.  This is used in pillar node drain path as well as replicated volume instance metrics.  Search for the longhorn-system namespace to determine if the longhorn http api is expected to be available.


(cherry picked from commit 250e0565f20b599a81c2c81f9100fa2b83eb3df6)

# Description

<!-- Clear description what this PR does and why it's needed -->

<!-- For Backport PRs, please note the following:

- Add a note to indicate the origin of the fix, for example:

Backport of #<original-PR-number>

- PR's title should also indicate the stable branch, for instance:

[<stable-branch>] Original's PR title
-->

## PR dependencies

<!-- List all dependencies of this PR (when applicable) -->

## How to test and validate this PR

<!-- Please describe how the changes in this PR can be validated or
verified. For example:

- If your PR fixes a bug, outline the steps to confirm the issue is resolved.
- If your PR introduces a new feature, explain how to test and validate it.
-->

## Changelog notes

<!-- Short description to be included in the ChangeLog notes -->

## PR Backports

<!-- When applicable, list all stable branches that must have this PR
backported. For example:

- [ ] 13.4-stable
- [ ] 12.0-stable
-->

## Checklist

- [ ] I've provided a proper description
- [ ] I've added the proper documentation (when applicable)
- [ ] I've tested my PR on amd64 device(s)
- [ ] I've tested my PR on arm64 device(s)
- [ ] I've written the test verification instructions
- [ ] I've set the proper labels to this PR
<!-- For Backport PRs only:
- [ ] I've added a reference link to the original PR
- [ ] PR's title follows the template ([<stable-branch>] Original's PR Title)
-->
