### PR TITLE
Init drainSkipK8sAPINotReachableTimeout to default

### DIFF
--- a/pkg/pillar/cmd/zedkube/zedkube.go
+++ b/pkg/pillar/cmd/zedkube/zedkube.go
@@ -176,7 +176,8 @@ func Run(ps *pubsub.PubSub, loggerArg *logrus.Logger, logArg *base.LogObject, ar
 	log = logArg
 
 	zedkubeCtx := zedkube{
-		globalConfig: types.DefaultConfigItemValueMap(),
+		globalConfig:                       types.DefaultConfigItemValueMap(),
+		drainSkipK8sAPINotReachableTimeout: 300,
 	}
 
 	// do we run a single command, or long-running service?


### PR DESCRIPTION
Otherwise defaults to 0 and causes node stuck reboot/shutdown.

(cherry picked from commit b52d5a5c41201129608d93ea373cbe4e9430a01b)


