### PR TITLE
Fix an issue of cluster mode transition not terminating k3s

### DIFF
--- a/pkg/kube/cluster-utils.sh
+++ b/pkg/kube/cluster-utils.sh
@@ -6,6 +6,7 @@
 LOG_SIZE=$((5*1024*1024))
 K3s_LOG_FILE="k3s.log"
 SAVE_KUBE_VAR_LIB_DIR="/persist/kube-save-var-lib"
+K3S_SERVER_CMD="k3s server"
 
 logmsg() {
         local MSG
@@ -47,10 +48,12 @@ check_log_file_size() {
                 # not releasing the file descriptor, so truncate the file may not
                 # take effect. Signal a HUP signal to that.
                 if [ "$1" = "$K3s_LOG_FILE" ]; then
-                        k3s_pid=$(pgrep -f "k3s server")
-                        if [ -n "$k3s_pid" ]; then
-                                kill -HUP "$k3s_pid"
-                                logmsg "Sent HUP signal to k3s server before truncate k3s.log size"
+                        k3s_pids=$(pgrep -f "$K3S_SERVER_CMD")
+                        if [ -n "$k3s_pids" ]; then
+                                for pid in $k3s_pids; do
+                                        kill -HUP "$pid"
+                                        logmsg "Sent HUP signal to k3s server before truncate k3s.log size"
+                                done
                         fi
                 fi
                 truncate -s 0 "$K3S_LOG_DIR/$1"
@@ -224,25 +227,62 @@ get_eve_os_release() {
 }
 
 terminate_k3s() {
-  # Find the process ID of 'k3s server'
-  pid=$(pgrep -f 'k3s server')
+  # Simple loop to kill all k3s server processes
+  max_attempts=5
+  attempt=0
 
-  # If the process exists, kill it
-  if [ -n "$pid" ]; then
-    logmsg "Killing 'k3s server' process with PID: $pid"
-    kill "$pid"
-  else
-    logmsg "'k3s server' process not found"
+  while [ $attempt -lt $max_attempts ]; do
+    # Check for any k3s server processes
+    pids=$(pgrep -f "$K3S_SERVER_CMD")
+
+    # If no processes found, we're done
+    if [ -z "$pids" ]; then
+      if [ $attempt -eq 0 ]; then
+        logmsg "No 'k3s server' processes found"
+      else
+        logmsg "k3s server processes successfully terminated"
+      fi
+      return 0
+    fi
+
+    for pid in $pids; do
+        if [ $attempt -eq 0 ]; then
+            # First attempt: use SIGTERM for graceful shutdown
+            logmsg "Sending SIGTERM to PID $pid for graceful shutdown"
+            kill "$pid" 2>/dev/null
+        else
+            # Subsequent attempts: use SIGKILL for forced termination
+            logmsg "Sending SIGKILL to PID $pid"
+            kill -9 "$pid" 2>/dev/null
+        fi
+    done
+
+    # Wait a moment for processes to terminate
+    sleep 1
+    attempt=$((attempt+1))
+  done
+
+  # Final check for any remaining processes
+  remaining_pids=$(pgrep -f "$K3S_SERVER_CMD")
+  if [ -n "$remaining_pids" ]; then
+    # Last resort: use pkill with -9
+    logmsg "Some processes still running after $max_attempts kill attempts"
+    pkill -9 -f "$K3S_SERVER_CMD" 2>/dev/null
+
+    sleep 1
+    final_check=$(pgrep -f "$K3S_SERVER_CMD")
+    if [ -n "$final_check" ]; then
+      logmsg "ERROR: Unable to kill all k3s server processes! Still running: $final_check"
+    fi
   fi
 }
 
 # wait for debugging flag in /persist/k3s/wait_{flagname} if exist
 wait_for_item() {
         filename="/persist/k3s/wait_$1"
-        processname="k3s server"
         while [ -e "$filename" ]; do
                 k3sproc=""
-                if pgrep -x "$processname" > /dev/null; then
+                if pgrep -x "$K3S_SERVER_CMD" > /dev/null; then
                         k3sproc="k3s server is running"
                 else
                         k3sproc="k3s server is NOT running"


### PR DESCRIPTION
- add code to prevent a timing issue to restart k3s while new configuration for transition is not ready
- fix an issue of pgrep for 'k3s server' may return multiple of PIDs

# Description

Provide a clear and concise description of the changes in this PR and
explain why they are necessary.

If the PR contains only one commit, you will see the commit message above:
fill free to use it under the description section here, if it is good enough.

For **Backport PRs**, a full description is optional, but please clearly state
the original PR number(s). Use the #{NUMBER} format for that, it makes it easier
to handle with the scripts later. For example:

> Backport of #1234, #5678, #91011

Title of a backport PR must also follow the following format:

> "[x.y-stable] Original PR title".

where `x.y-stable` is the name of the target stable branch, and
`Original PR title` is the title of the original PR.

For example, for a PR that backports a PR with title `Fix the nasty bug` to
branch `13.4-stable` the title should be:
`[13.4-stable] Fix the nasty bug`.

## PR dependencies

List all dependencies of this PR (when applicable, otherwise remove this
section).

## How to test and validate this PR

Please describe how the changes in this PR can be validated or verified. For
example:

- If your PR fixes a bug, outline the steps to confirm the issue is resolved.
- If your PR introduces a new feature, explain how to test and validate it.

This will be used

1. to provide test scenarios for the QA team
1. by a reviewer to validate the changes in this PR.

The first is especially important, so, please make sure to provide as much
detail as possible.

If it's covered by an automated test, please mention it here.

## Changelog notes

Text in this section will be used to generate the changelog entry for
release notes. The consumers of this are end users, not developers.
So, provide a clear and short description of what is changed in the PR from
the end user perspective. If it changes only tooling or some internal
implementation, put a note like "No user-facing changes" or "None".

## PR Backports

For all current LTS branches, please state explicitly if this PR should be
backported or not. This section is used by our scripts to track the backports,
so, please, do not omit it.

Here is the list of current LTS branches (it should be always up to date):

- 14.5-stable
- 13.4-stable

For example, if this PR fixes a bug in a feature that was introduced in 14.5,
you can write:

```text
- 14.5-stable: To be backported.
- 13.4-stable: No, as the feature is not available there.
```

Also, to the PRs that should be backported into any stable branch, please
add a label `stable`.

## Checklist

- [ ] I've provided a proper description
- [ ] I've added the proper documentation
- [ ] I've tested my PR on amd64 device
- [ ] I've tested my PR on arm64 device
- [ ] I've written the test verification instructions
- [ ] I've set the proper labels to this PR

For backport PRs (remove it if it's not a backport):

- [ ] I've added a reference link to the original PR
- [ ] PR's title follows the template

And the last but not least:

- [ ] I've checked the boxes above, or I've provided a good reason why I didn't
  check them.

Please, check the boxes above after submitting the PR in interactive mode.
