### PR TITLE
Enable Node Convert to base k3s.

### DIFF
--- a/pkg/kube/cluster-init.sh
+++ b/pkg/kube/cluster-init.sh
@@ -626,7 +626,7 @@ monitor_cluster_config_change() {
 
 # started when we detect registration addition
 # start cleaning up some components
-# these are cluster-wide operations, only one nodes initates it
+# these are cluster-wide operations, only one nodes initiates it
 # Marked via the Registration_Exists fence
 uninstall_components() {
         logmsg "Post-registration cleanup steps: wait api available"
@@ -1020,7 +1020,7 @@ fi
         check_kubeconfig_yaml_files
         check_and_remove_excessive_k3s_logs
         check_and_run_vnc
-        if ! Registration_Exists; then
+        if ! Registration_Applied; then
                 # Upgrades declared via EVE baseOS updates
                 Update_CheckClusterComponents
                 Update_RunDeschedulerOnBoot

--- a/pkg/kube/kubevirt-utils.sh
+++ b/pkg/kube/kubevirt-utils.sh
@@ -24,8 +24,8 @@ Kubevirt_uninstall() {
     kubectl delete -f /etc/kubevirt-operator.yaml
 
     # Kubevirt applies a large amount of labels to nodes detailing available cpu flags, remove them
-    for n in $(kubectl get node -o NAME); do 
-        logmsg "removing kubevirt.io labels from node: $n"; 
+    for n in $(kubectl get node -o NAME); do
+        logmsg "removing kubevirt.io labels from node: $n"
         labelsToRemove=$(kubectl get "$n" -o json | jq -r '.metadata.labels | to_entries[] | select(.key | contains("kubevirt.io")) | .key' | awk '{printf "%s- ", $0}')
         kubectl label $n $labelsToRemove
     done

--- a/pkg/kube/longhorn-generate-support-bundle.sh
+++ b/pkg/kube/longhorn-generate-support-bundle.sh
@@ -6,7 +6,7 @@
 LOG_DIR=/persist/kubelog
 
 # This script is called from collect-info, help it avoid a timeout
-# by checking for longhorn installed state and return before applying 
+# by checking for longhorn installed state and return before applying
 # the support bundle manifest.
 if ! kubectl get namespace/longhorn-system; then
     echo "Longhorn not installed, skipping SupportBundle"

--- a/pkg/kube/registration-utils.sh
+++ b/pkg/kube/registration-utils.sh
@@ -3,9 +3,9 @@
 # Copyright (c) 2025 Zededa, Inc.
 # SPDX-License-Identifier: Apache-2.0
 
-# Dir which pillar has access to
+# Dir which pillar service container has access to
 PERSIST_MANIFESTS_DIR=/persist/vault/manifests
-# Path which k3s monitors
+# Dir which kube service container has access to and k3s monitors
 KUBE_MANIFESTS_DIR=/var/lib/rancher/k3s/server/manifests
 
 YAML_EXT="yaml"
@@ -20,7 +20,7 @@ appliedRegistrationYamlFileName="${appliedRegistrationYamlName}.${YAML_EXT}"
 appliedRegistrationYamlFilePath="${KUBE_MANIFESTS_DIR}/${appliedRegistrationYamlFileName}"
 
 # Pillar may download a yaml for registration, copy it in so that k3s handles applying it
-# This should be called in a very infrequently called cluster-config-change path 
+# This should be called in a very infrequently called cluster-config-change path
 Registration_CheckApply() {
     if [ ! -d "${PERSIST_MANIFESTS_DIR}" ]; then
         return
@@ -41,11 +41,22 @@ Registration_Cleanup() {
     return 0
 }
 
+# Registration_Exists checks if the local eve fs contains
+# a registration file, this will only exist on one node.
 Registration_Exists() {
     if [ -e "${appliedRegistrationYamlFilePath}" ]; then
         return 0
     fi
     return 1
+}
+
+# Registration_Applied checks if the cluster contains the pointer
+# marking that a registration manifest has been applied by k3s.
+# This marker allows an agnostic check that the manifest has been applied
+# regardless of the manifest's specific object contents
+Registration_Applied() {
+    kubectl -n kube-system get AddOn/${appliedRegistrationYamlName} > /dev/null 2>&1
+    return $?
 }
 
 # delete the files from persist so that we don't re-apply them


### PR DESCRIPTION
latest from master

- Move component install steps to clean functions
- Uninstall components if registration completes. This marks conversion from edge node storage cluster which provides VMs on replicated storage to a simpler kubernetes cluster awaiting further config.
- Enable all_components_initialized on arm64 by skipping install of kubevirt/cdi components.  CDI is amd64 only at least in this  version.
- Skip calling longhorn API when it's not expected to be available.  This is used in pillar node drain path as well as replicated volume instance metrics.  Search for the longhorn-system namespace to determine if the longhorn http api is expected to be available.


(cherry picked from commit 220d17ad3600af495f77d2e7c2da9fd259384b2b)
