### PR TITLE
Cleanup DetachOldWorkload path

### DIFF
--- a/pkg/pillar/cmd/zedkube/drain.go
+++ b/pkg/pillar/cmd/zedkube/drain.go
@@ -163,10 +163,11 @@ func cordonAndDrainNode(ctx *zedkube) {
 	//
 	// 1. Attempt to safely handle the case where the kube api is down
 	//	for an extended period of time and the controller requested device operation is needed anyways.
+	//  eg. k3s not running on local node due to needing a reboot operation.
 	//
-	unavail, err := isExtendedKubeAPIUnreachable(time.Second * time.Duration(ctx.drainSkipK8sAPINotReachableTimeout))
+	unavail, err := isExtendedKubeAPIUnreachable(ctx.drainSkipK8sAPINotReachableTimeout)
 	if unavail && (err == nil) {
-		log.Notice("cordonAndDrainNode nodedrain-step:drain-complete due to extended kube api service unreachability")
+		log.Noticef("cordonAndDrainNode nodedrain-step:drain-complete due to extended kube api service unreachability after duration:%v", ctx.drainSkipK8sAPINotReachableTimeout)
 		publishNodeDrainStatus(ctx, kubeapi.COMPLETE)
 		return
 	}
@@ -310,7 +311,7 @@ func drainNode(ctx *zedkube) error {
 		Out:                   &drainLogger{log: log, err: false},
 		ErrOut:                &drainLogger{log: log, err: true},
 		DeleteEmptyDirData:    true,
-		Timeout:               time.Hour * time.Duration(ctx.drainTimeoutHours),
+		Timeout:               ctx.drainTimeout,
 		PodSelector:           podSelectorStr,
 		OnPodDeletedOrEvicted: onPodDeletedOrEvicted,
 	}

--- a/pkg/pillar/cmd/zedkube/zedkube.go
+++ b/pkg/pillar/cmd/zedkube/zedkube.go
@@ -96,8 +96,8 @@ type zedkube struct {
 	drainOverrideTimer       *time.Timer
 
 	// Config Properties for Drain
-	drainTimeoutHours                  uint32
-	drainSkipK8sAPINotReachableTimeout uint32
+	drainTimeout                       time.Duration
+	drainSkipK8sAPINotReachableTimeout time.Duration
 
 	// Block 'uncordon' after running it once at bootup
 	onBootUncordonCheckComplete bool
@@ -177,7 +177,8 @@ func Run(ps *pubsub.PubSub, loggerArg *logrus.Logger, logArg *base.LogObject, ar
 
 	zedkubeCtx := zedkube{
 		globalConfig:                       types.DefaultConfigItemValueMap(),
-		drainSkipK8sAPINotReachableTimeout: 300,
+		drainSkipK8sAPINotReachableTimeout: time.Duration(time.Second * types.DefaultDrainSkipK8sAPINotReachableTimeoutSeconds),
+		drainTimeout:                       time.Duration(time.Hour * types.DefaultDrainTimeoutHours),
 	}
 
 	// do we run a single command, or long-running service?
@@ -670,7 +671,7 @@ func handleGlobalConfigImpl(ctxArg interface{}, key string,
 		if newDrainTimeout != 0 && newDrainTimeout != existingDrainTimeout {
 			log.Functionf("handleGlobalConfigImpl: Updating drainTimeoutHours from %d to %d",
 				existingDrainTimeout, newDrainTimeout)
-			z.drainTimeoutHours = newDrainTimeout
+			z.drainTimeout = time.Hour * time.Duration(newDrainTimeout)
 		}
 
 		//
@@ -681,7 +682,7 @@ func handleGlobalConfigImpl(ctxArg interface{}, key string,
 		if newDrainK8sAPINotReachableTimeout != 0 && newDrainK8sAPINotReachableTimeout != existingDrainK8sAPINotReachableTimeout {
 			log.Functionf("handleGlobalConfigImpl: Updating drainSkipK8sApiTimeout from %d to %d",
 				existingDrainK8sAPINotReachableTimeout, newDrainK8sAPINotReachableTimeout)
-			z.drainSkipK8sAPINotReachableTimeout = newDrainK8sAPINotReachableTimeout
+			z.drainSkipK8sAPINotReachableTimeout = time.Second * time.Duration(newDrainK8sAPINotReachableTimeout)
 		}
 	}
 	log.Functionf("handleGlobalConfigImpl(%s): done", key)

--- a/pkg/pillar/types/global.go
+++ b/pkg/pillar/types/global.go
@@ -1025,8 +1025,8 @@ func NewConfigItemSpecMap() ConfigItemSpecMap {
 	configItemSpecMap.AddIntItem(GoroutineLeakDetectionCooldownMinutes, 5, 1, 0xFFFFFFFF)
 
 	// Kubevirt Drain Section
-	configItemSpecMap.AddIntItem(KubevirtDrainTimeout, 24, 1, 0xFFFFFFFF)
-	configItemSpecMap.AddIntItem(KubevirtDrainSkipK8sAPINotReachableTimeout, 300, 1, 0xFFFFFFFF)
+	configItemSpecMap.AddIntItem(KubevirtDrainTimeout, DefaultDrainTimeoutHours, 1, 0xFFFFFFFF)
+	configItemSpecMap.AddIntItem(KubevirtDrainSkipK8sAPINotReachableTimeout, DefaultDrainSkipK8sAPINotReachableTimeoutSeconds, 1, 0xFFFFFFFF)
 
 	// Add Bool Items
 	configItemSpecMap.AddBoolItem(UsbAccess, true) // Controller likely default to false

--- a/pkg/pillar/types/zedkubetypes.go
+++ b/pkg/pillar/types/zedkubetypes.go
@@ -12,6 +12,21 @@ import (
 	corev1 "k8s.io/api/core/v1"
 )
 
+const (
+	// DefaultDrainSkipK8sAPINotReachableTimeoutSeconds is the time duration which the drain request handler
+	// will continue retrying the k8s api before declaring the node is unavailable and continuing
+	// device operations (reboot/shutdown/upgrade)
+	// This covers the following k8s.io/apimachinery/pkg/api/errors
+	// IsInternalError
+	// IsServerTimeout
+	// IsServiceUnavailable
+	// IsTimeout
+	// IsTooManyRequests
+	DefaultDrainSkipK8sAPINotReachableTimeoutSeconds = 300
+	// DefaultDrainTimeoutHours is time allowed for a node drain before a failure is returned
+	DefaultDrainTimeoutHours = 24
+)
+
 // KubeNodeStatus - Enum for the status of a Kubernetes node
 type KubeNodeStatus int8
 


### PR DESCRIPTION
- only delete VA path in DetachOldWorkload
- find VA by node name, otherwise can early exit with VA from new attachment then not delete old one.
- force delete virt-handler pod from deployment on failed node, only if it exists one per node, not per app
- all force deletes in foreground
- fix data type of grace period passed to VA delete.
