### PR TITLE
Fast VMI Failover on detection of NodeUnreachable

### DIFF
--- a/pkg/debug/scripts/collect-info.sh
+++ b/pkg/debug/scripts/collect-info.sh
@@ -373,6 +373,10 @@ collect_kube_info()
            echo "============"
            eve exec kube kubectl top pod -A --sum
            echo "============"
+           echo "kubectl get volumeattachment"
+           echo "============"
+           eve exec kube kubectl get volumeattachment
+           echo "============"
         } > "$DIR/kube-info"
     fi
 }

--- a/pkg/kube/Dockerfile
+++ b/pkg/kube/Dockerfile
@@ -53,6 +53,7 @@ COPY iscsid.conf /etc/iscsi/
 COPY longhorn-generate-support-bundle.sh /usr/bin/
 COPY nsmounter /usr/bin/
 COPY longhorn_uninstall_settings.yaml /etc/
+COPY failover-events.sh /usr/bin/
 
 # descheduler
 COPY descheduler-utils.sh /usr/bin/

--- a/pkg/kube/failover-events.sh
+++ b/pkg/kube/failover-events.sh
@@ -1,0 +1,56 @@
+#!/bin/bash
+# Usage: ./failover-events.sh <replicaset-prefix>
+set -e
+
+PREFIX="$1"
+NAMESPACE="eve-kube-app"
+
+if [ -z "$PREFIX" ]; then
+  echo "Usage: $0 <replicaset-prefix>"
+  exit 1
+fi
+
+VMIRS_NAMES=$(kubectl get vmirs -n "$NAMESPACE" --no-headers | awk '{print $1}' | grep "^$PREFIX")
+for vmirs in $VMIRS_NAMES; do
+  appDomainNameSelector=$(kubectl -n "$NAMESPACE" get vmirs/${vmirs} -o json | jq -r .status.labelSelector)
+
+  # Find all VMI names matching the prefix
+  VMI_NAMES=$(kubectl get vmi -n "$NAMESPACE" -l "$appDomainNameSelector" --no-headers | awk '{print $1}')
+
+  # Find all virt-launcher pods associated with those VMIs
+  POD_NAMES=""
+  PVC_NAMES=""
+  LH_VOL_NAMES=""
+  LH_VOL_REPS=""
+  for vmi in $VMI_NAMES; do
+    pods=$(kubectl get pods -n "$NAMESPACE" -l "$appDomainNameSelector" --no-headers | awk '{print $1}')
+    POD_NAMES="$POD_NAMES $pods"
+
+    # All PVCs for this pod
+    for pod in $pods; do
+      pvcs=$(kubectl get pod -n "$NAMESPACE" -l "$appDomainNameSelector" -o json | jq -r '.items[].spec.volumes[] | select(.persistentVolumeClaim) | .persistentVolumeClaim.claimName')
+      PVC_NAMES="$PVC_NAMES $pvcs"
+      for pvc in $pvcs; do
+        volname=$(kubectl -n "$NAMESPACE" get pvc/${pvc} -o json | jq -r .spec.volumeName)
+        LH_VOL_NAMES="$LH_VOL_NAMES $volname"
+
+        reps=$(kubectl -n longhorn-system get replicas -l longhornvolume=$volname)
+        LH_VOL_REPS="$LH_VOL_REPS $reps"
+      done
+    done
+  done
+
+  # Collect all relevant object names
+  OBJECTS="$vmirs $VMI_NAMES $POD_NAMES $PVC_NAMES"
+  LHOBJECTS="$LH_VOL_NAMES $LH_VOL_REPS"
+
+  # Get events for each object and print them with creationTimestamp
+  for obj in $OBJECTS; do
+    kubectl get events -n "$NAMESPACE" --field-selector involvedObject.name="$obj" -o json \
+      | jq -r '.items[] | [.metadata.creationTimestamp, .involvedObject.kind, .involvedObject.name, .reason, .message] | @tsv'
+  done | sort
+  for obj in $LHOBJECTS; do
+    kubectl get events -n longhorn-system --field-selector involvedObject.name="$obj" -o json \
+      | jq -r '.items[] | [.metadata.creationTimestamp, .involvedObject.kind, .involvedObject.name, .reason, .message] | @tsv'
+  done | sort
+done

--- a/pkg/kube/kubevirt-utils.sh
+++ b/pkg/kube/kubevirt-utils.sh
@@ -11,11 +11,19 @@ Kubevirt_install() {
     logmsg "Installing patched Kubevirt"
     kubectl apply -f /etc/kubevirt-operator.yaml
     logmsg "Updating replica to 1 for virt-operator and virt-controller"
-    kubectl patch deployment virt-operator -n kubevirt --patch '{"spec":{"replicas": 1 }}'
+    kubectl patch deployment virt-operator -n kubevirt --patch '{"spec":{"replicas": 3 }}'
     kubectl apply -f https://github.com/kubevirt/kubevirt/releases/download/${KUBEVIRT_VERSION}/kubevirt-cr.yaml
-    kubectl patch KubeVirt kubevirt -n kubevirt --patch '{"spec": {"infra": {"replicas": 1}}}' --type='merge'
+    kubectl patch KubeVirt kubevirt -n kubevirt --patch '{"spec": {"infra": {"replicas": 3}}}' --type='merge'
     #Add kubevirt feature gates
     kubectl apply -f /etc/kubevirt-features.yaml
+}
+
+Kubevirt_config() {
+    if ! kubectl get namespace/kubevirt; then 
+        return
+    fi
+    kubectl patch deployment virt-operator -n kubevirt --patch '{"spec":{"replicas": 3 }}'
+    kubectl patch KubeVirt kubevirt -n kubevirt --patch '{"spec": {"infra": {"replicas": 3}}}' --type='merge'
 }
 
 Kubevirt_uninstall() {

--- a/pkg/kube/longhorn-generate-support-bundle.sh
+++ b/pkg/kube/longhorn-generate-support-bundle.sh
@@ -13,6 +13,16 @@ if ! kubectl get namespace/longhorn-system; then
     exit 1
 fi
 
+echo "============"
+echo "kubectl -n longhorn-system get replicaset,deployment,daemonset,service,pod,volume,replica,engine,engineimage,nodes.longhorn.io,volumeattachments.longhorn.io -o wide"
+echo "============"
+kubectl -n longhorn-system get replicaset,deployment,daemonset,service,pod,volume,replica,engine,engineimage,nodes.longhorn.io,volumeattachments.longhorn.io -o wide
+echo "============"
+echo "kubectl -n longhorn-system get volume fields:  .metadata.name spec.nodeID status.currentNodeID status.ownerID status.pendingNodeId"
+echo "============"
+kubectl -n longhorn-system get volume -o json | jq '.items[] | "name:\(.metadata.name) spec.nodeID:\(.spec.nodeID) status.currentNodeID:\(.status.currentNodeID) status.ownerID:\(.status.ownerID) status.pendingNodeId:\(.status.pendingNodeID)"'
+echo "============"
+
 echo "Apply longhorn support bundle yaml at $(date)"
 
 cat <<EOF | kubectl apply -f -

--- a/pkg/pillar/base/logobjecttypes.go
+++ b/pkg/pillar/base/logobjecttypes.go
@@ -6,7 +6,8 @@ package base
 import (
 	"encoding/json"
 	"fmt"
-	"github.com/satori/go.uuid"
+
+	uuid "github.com/satori/go.uuid"
 	"github.com/sirupsen/logrus"
 )
 
@@ -174,6 +175,8 @@ const (
 	CachedResolvedIPsLogType LogObjectType = "cached_resolved_ips"
 	// AppMACGeneratorLogType : type for AppMACGenerator log entries
 	AppMACGeneratorLogType LogObjectType = "app_mac_generator"
+	// KubeAppFailover
+	KubeAppFailover LogObjectType = "kube_app_failover"
 )
 
 // RelationObjectType :

--- a/pkg/pillar/cmd/zedkube/zedkube.go
+++ b/pkg/pillar/cmd/zedkube/zedkube.go
@@ -6,7 +6,9 @@
 package zedkube
 
 import (
+	"io"
 	"net/http"
+	"os"
 	"strconv"
 	"strings"
 	"sync"
@@ -20,6 +22,7 @@ import (
 	"github.com/lf-edge/eve/pkg/pillar/kubeapi"
 	"github.com/lf-edge/eve/pkg/pillar/pubsub"
 	"github.com/lf-edge/eve/pkg/pillar/types"
+	uuid "github.com/satori/go.uuid"
 	"github.com/sirupsen/logrus"
 	"k8s.io/client-go/rest"
 )
@@ -35,6 +38,7 @@ const (
 	vmiVNCFileName = "/run/zedkube/vmiVNC.run"
 
 	inlineCmdKubeClusterUpdateStatus = "pubKubeClusterUpdateStatus"
+	inlineCmdVmiDetach               = "vmiDetach"
 )
 
 var (
@@ -105,6 +109,7 @@ type zedkube struct {
 
 func inlineUsage() int {
 	log.Errorf("Usage: zedkube %s <node> <component> <status> <DestinationKubeUpdateVersion> <error>", inlineCmdKubeClusterUpdateStatus)
+	log.Errorf("Usage: zedkube %s <unreachable node name> <app domain name>", inlineCmdVmiDetach)
 	return 1
 }
 
@@ -163,6 +168,22 @@ func runCommand(ps *pubsub.PubSub, command string, args []string) int {
 			}
 			pubKubeClusterUpdateStatus.Publish("global", upStatusObj)
 		}
+	case inlineCmdVmiDetach:
+		if args == nil {
+			return inlineUsage()
+		}
+		nodeName := args[0]
+		appDomainName := args[1]
+
+		file, _ := os.OpenFile("/persist/kubelog/detach.log", os.O_CREATE|os.O_WRONLY|os.O_APPEND, 0666)
+		mw := io.MultiWriter(os.Stdout, file)
+		logger := logrus.New()
+		logger.SetOutput(mw)
+		baseLogObj := base.NewSourceLogObject(logger, "zedkube_inline", os.Getpid())
+		logObj := base.NewLogObject(baseLogObj, base.KubeAppFailover, "zedkube_inline", uuid.Nil, "detach-key")
+
+		logObj.Noticef("zedkube inline %s node:%s appDomainName:%s", inlineCmdVmiDetach, nodeName, appDomainName)
+		kubeapi.DetachOldWorkload(logObj, nodeName, appDomainName)
 	default:
 		log.Errorf("Unknown command %s", command)
 		return 99


### PR DESCRIPTION
Detect when a kubernetes node has become NotReady/NodeUnreachable. Find all VMIs running on that node and fully mark them deleted to allow that workload to be scheduled and running on another Ready node in the cluster.

This process has a series of steps which must be performed and some are node dependent and some have required order.

Detailed docs coming

failover-events.sh: a new script added to aid in debugging failover
	pass it the VM app instance name (vmirs name prefix)
	Output to the console will be all kubernetes events associated
	with the vmirs, pod, vmi, pvc, volume, replica sorted by time.

Extension of waitForVMI time 5min->15min to allow longer failovers to complete.

# Description

Provide a clear and concise description of the changes in this PR and
explain why they are necessary.

If the PR contains only one commit, you will see the commit message above:
fill free to use it under the description section here, if it is good enough.

For **Backport PRs**, a full description is optional, but please clearly state
the original PR number(s). Use the #{NUMBER} format for that, it makes it easier
to handle with the scripts later. For example:

> Backport of #1234, #5678, #91011

Title of a backport PR must also follow the following format:

> "[x.y-stable] Original PR title".

where `x.y-stable` is the name of the target stable branch, and
`Original PR title` is the title of the original PR.

For example, for a PR that backports a PR with title `Fix the nasty bug` to
branch `13.4-stable` the title should be:
`[13.4-stable] Fix the nasty bug`.

## PR dependencies

List all dependencies of this PR (when applicable, otherwise remove this
section).

## How to test and validate this PR

Please describe how the changes in this PR can be validated or verified. For
example:

- If your PR fixes a bug, outline the steps to confirm the issue is resolved.
- If your PR introduces a new feature, explain how to test and validate it.

This will be used

1. to provide test scenarios for the QA team
1. by a reviewer to validate the changes in this PR.

The first is especially important, so, please make sure to provide as much
detail as possible.

If it's covered by an automated test, please mention it here.

## Changelog notes

Text in this section will be used to generate the changelog entry for
release notes. The consumers of this are end users, not developers.
So, provide a clear and short description of what is changed in the PR from
the end user perspective. If it changes only tooling or some internal
implementation, put a note like "No user-facing changes" or "None".

## PR Backports

For all current LTS branches, please state explicitly if this PR should be
backported or not. This section is used by our scripts to track the backports,
so, please, do not omit it.

Here is the list of current LTS branches (it should be always up to date):

- 14.5-stable
- 13.4-stable

For example, if this PR fixes a bug in a feature that was introduced in 14.5,
you can write:

```text
- 14.5-stable: To be backported.
- 13.4-stable: No, as the feature is not available there.
```

Also, to the PRs that should be backported into any stable branch, please
add a label `stable`.

## Checklist

- [ ] I've provided a proper description
- [ ] I've added the proper documentation
- [ ] I've tested my PR on amd64 device
- [ ] I've tested my PR on arm64 device
- [ ] I've written the test verification instructions
- [ ] I've set the proper labels to this PR

For backport PRs (remove it if it's not a backport):

- [ ] I've added a reference link to the original PR
- [ ] PR's title follows the template

And the last but not least:

- [ ] I've checked the boxes above, or I've provided a good reason why I didn't
  check them.

Please, check the boxes above after submitting the PR in interactive mode.
