### PR TITLE
Failover: baseos updates should drain, wd update in failover loop

### DIFF
--- a/pkg/pillar/cmd/zedkube/applogs.go
+++ b/pkg/pillar/cmd/zedkube/applogs.go
@@ -125,7 +125,7 @@ func (z *zedkube) collectAppLogs() {
 	}
 }
 
-func (z *zedkube) checkAppsStatus() {
+func (z *zedkube) checkAppsStatus(wdFunc func()) {
 	sub := z.subAppInstanceConfig
 	items := sub.GetAll()
 	if len(items) == 0 {
@@ -153,6 +153,8 @@ func (z *zedkube) checkAppsStatus() {
 
 	var oldStatus *types.ENClusterAppStatus
 	for _, item := range items {
+		wdFunc()
+
 		aiconfig := item.(types.AppInstanceConfig)
 		encAppStatus := types.ENClusterAppStatus{
 			AppUUID:    aiconfig.UUIDandVersion.UUID,

--- a/pkg/pillar/cmd/zedkube/zedkube.go
+++ b/pkg/pillar/cmd/zedkube/zedkube.go
@@ -558,6 +558,10 @@ func Run(ps *pubsub.PubSub, loggerArg *logrus.Logger, logArg *base.LogObject, ar
 	}
 	appLogTimer := time.NewTimer(logcollectInterval * time.Second)
 
+	zedkubeWdUpdate := func() {
+		ps.StillRunning(agentName, warningTime, errorTime)
+	}
+
 	log.Notice("zedkube online")
 
 	for {
@@ -570,7 +574,7 @@ func Run(ps *pubsub.PubSub, loggerArg *logrus.Logger, logArg *base.LogObject, ar
 
 		case <-appLogTimer.C:
 			zedkubeCtx.collectAppLogs()
-			zedkubeCtx.checkAppsStatus()
+			zedkubeCtx.checkAppsStatus(zedkubeWdUpdate)
 			zedkubeCtx.collectKubeStats()
 			zedkubeCtx.collectKubeSvcs()
 			appLogTimer = time.NewTimer(logcollectInterval * time.Second)


### PR DESCRIPTION
baseosmgr: states seen during update has changed which led
	to drain no longer getting requested. Refined the
	code to also read ContentTreeStatus.State and rewrite the
	conditional for readability of needed state.

zedkube: checkAppsStatus should update StillRunning to help
	avoid a watchdog while failing over multiple apps.


