### PR TITLE
Improve pvc upload reliability

### DIFF
--- a/pkg/kube/Dockerfile
+++ b/pkg/kube/Dockerfile
@@ -81,7 +81,7 @@ ARG TARGETARCH
 
 # Actual k3s install and config happens when this container starts during EVE bootup, look at cluster-init.sh
 ### NOTE: the version of virtctl should match the version of kubevirt in cluster_init.sh, else PVC creation might fail due to incompatibility
-ENV VIRTCTL_VERSION v1.1.0
+ENV VIRTCTL_VERSION v1.6.0
 ADD https://github.com/kubevirt/kubevirt/releases/download/${VIRTCTL_VERSION}/virtctl-${VIRTCTL_VERSION}-linux-${TARGETARCH} .
 
 RUN install virtctl-${VIRTCTL_VERSION}-linux-${TARGETARCH} /usr/bin/virtctl

--- a/pkg/pillar/kubeapi/vitoapiserver.go
+++ b/pkg/pillar/kubeapi/vitoapiserver.go
@@ -9,6 +9,7 @@ import (
 	"context"
 	"fmt"
 	"math"
+	"strconv"
 	"strings"
 	"time"
 
@@ -278,11 +279,13 @@ func RolloutDiskToPVC(ctx context.Context, log *base.LogObject, exists bool,
 	// Sample virtctl command
 	// virtctl image-upload -n eve-kube-app pvc pvcname  --no-create --storage-class longhorn --image-path=<diskfile>
 	// --insecure --uploadproxy-url https://10.43.31.180:8443  --access-mode RWO --block-volume --size 1000M
-	//uploadPodServerStartTimeBase := int64(600) // First upload may need to wait for image download of the uploader itself
 
+	uploadPodServerStartTimeBase := int64(600) // First upload may need to wait for image download of the uploader itself
+	virtctlUploadServerRetryMax := int64(10)
 	args := []string{"image-upload", "-n", EVEKubeNameSpace, "pvc", pvcName,
 		"--storage-class", "longhorn", "--image-path", diskfile, "--insecure",
-		"--uploadproxy-url", uploadproxyURL, "--kubeconfig", EVEkubeConfigFile}
+		"--uploadproxy-url", uploadproxyURL, "--kubeconfig", EVEkubeConfigFile,
+		"--retry", strconv.FormatInt(virtctlUploadServerRetryMax, 10), "--wait-secs", strconv.FormatInt(uploadPodServerStartTimeBase, 10)}
 
 	args = append(args, "--access-mode", "ReadWriteOnce")
 
@@ -308,7 +311,7 @@ func RolloutDiskToPVC(ctx context.Context, log *base.LogObject, exists bool,
 	timeoutBaseSeconds := int64(300) // 5 min
 	volSizeGB := int64(pvcSize / 1024 / 1024 / 1024)
 	timeoutPer1GBSeconds := int64(120)
-	timeout := time.Duration(timeoutBaseSeconds + (volSizeGB * timeoutPer1GBSeconds))
+	timeout := time.Duration(uploadPodServerStartTimeBase + timeoutBaseSeconds + (volSizeGB * timeoutPer1GBSeconds))
 	log.Noticef("RolloutDiskToPVC pvc:%s calculated timeout to %d seconds due to volume size %d GB", pvcName, timeout, volSizeGB)
 
 	startTimeOverall := time.Now()


### PR DESCRIPTION
# Description

move to virtctl 1.6.0 for --retry support
account for upload pod image download time in timeout calculation

## PR dependencies

None

## How to test and validate this PR

Deploy a VM app-instance

## Changelog notes

None

## PR Backports

14.5-stable: probably

## Checklist

- [x] I've provided a proper description
- [x] I've added the proper documentation
- [x] I've tested my PR on amd64 device
- [ ] I've tested my PR on arm64 device
- [x] I've written the test verification instructions
- [ ] I've set the proper labels to this PR

- [x] I've checked the boxes above, or I've provided a good reason why I didn't
  check them.

