### PR TITLE
fix an typo in controller cert in zedkube

### DIFF
--- a/pkg/pillar/cmd/zedkube/zedkube.go
+++ b/pkg/pillar/cmd/zedkube/zedkube.go
@@ -419,8 +419,8 @@ func Run(ps *pubsub.PubSub, loggerArg *logrus.Logger, logArg *base.LogObject, ar
 		select {
 		case change := <-subControllerCert.MsgChan():
 			subControllerCert.ProcessChange(change)
-			log.Noticef("EdgeNodeCert, len %d", len(subEdgeNodeCert.GetAll()))
-			if len(subEdgeNodeCert.GetAll()) > 0 {
+			log.Noticef("ControllerCert, len %d", len(subControllerCert.GetAll()))
+			if len(subControllerCert.GetAll()) > 0 {
 				controllerCertInitialized = true
 			}
 


### PR DESCRIPTION
# Description

fix an typo in previous PR, the one in master is fine:
https://github.com/lf-edge/eve/pull/5156

## PR dependencies

## Changelog notes

fix an typo in controller cert in zedkube

## PR Backports


## Checklist

- [x] I've provided a proper description
- [ ] I've added the proper documentation
- [ ] I've tested my PR on amd64 device
- [ ] I've tested my PR on arm64 device
- [ ] I've written the test verification instructions
- [ ] I've set the proper labels to this PR

- [ ] I've added a reference link to the original PR
- [ ] PR's title follows the template

And the last but not least:

- [ ] I've checked the boxes above, or I've provided a good reason why I didn't
  check them.

Please, check the boxes above after submitting the PR in interactive mode.
